### PR TITLE
zsh config for "C-s" in terminal

### DIFF
--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -60,6 +60,7 @@
 
     alias ..="cd ../"
     alias dotfiles="git -c core.excludesFile=~/.dotignore --git-dir=$HOME/.dotfiles/ --work-tree=$HOME"
+    stty -ixon
   '';
   environment.systemPackages = with pkgs; [zshThemes.spaceship];
   users.defaultUserShell = pkgs.zsh;


### PR DESCRIPTION
C-s in terminal not freezing anymore. It was an old feature for old terminals and old hardware.