### PR TITLE
[neovim] tab completion better behavior, remove set shell because nixos defaults

### DIFF
--- a/overlays/neovim/options.vim.nix
+++ b/overlays/neovim/options.vim.nix
@@ -38,7 +38,7 @@ set inccommand=nosplit
 set updatetime=750
 set list listchars=tab:▷\ ,space:·,extends:»,precedes:«,nbsp:⦸
 set statusline=2
-set shell=/usr/bin/env\ bash
+set wildmode=longest:full,full
 
 if has('termguicolors')
   set termguicolors


### PR DESCRIPTION
A better behavior of neovim wildmode. If you wrote a word followed by a space and hit enter, the expectation is to show a menu and not to complete. After second tab start to complete. Now this is correct. 
I removed set shell to /usr/bin/env bash because the default shell is /run/current-system/sw/bin/zsh and sometimes within n/vim not find paths.
Thank you.